### PR TITLE
[lab-mysql] Roberto Henriquez Perozo

### DIFF
--- a/module-1/lab-mysql/your-code/create.sql
+++ b/module-1/lab-mysql/your-code/create.sql
@@ -1,0 +1,90 @@
+-- MySQL Workbench Forward Engineering
+
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
+
+-- -----------------------------------------------------
+-- Schema lab_mysql
+-- -----------------------------------------------------
+
+-- -----------------------------------------------------
+-- Schema lab_mysql
+-- --------------------------------Cars---------------------
+CREATE SCHEMA IF NOT EXISTS `lab_mysql` DEFAULT CHARACTER SET utf8 ;
+USE `lab_mysql` ;
+
+-- -----------------------------------------------------
+-- Table `lab_mysql`.`Customers`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `lab_mysql`.`Customers` (
+  `CustomerID` INT NOT NULL,
+  `name` VARCHAR(45) NOT NULL,
+  `phone_number` INT NOT NULL,
+  `email` VARCHAR(45) NULL,
+  `address` VARCHAR(45) NULL,
+  `city` VARCHAR(45) NOT NULL,
+  `country` VARCHAR(45) NOT NULL,
+  `ZIP` INT NULL,
+  PRIMARY KEY (`CustomerID`))
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table `lab_mysql`.`Salespersons`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `lab_mysql`.`Salespersons` (
+  `StaffID` INT NOT NULL,
+  `name` VARCHAR(45) NOT NULL,
+  `store` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`StaffID`))
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table `lab_mysql`.`Cars`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `lab_mysql`.`Cars` (
+  `VIN` VARCHAR(45) NOT NULL,
+  `manufacturer` VARCHAR(45) NOT NULL,
+  `model` VARCHAR(45) NOT NULL,
+  `year` INT NOT NULL,
+  `color` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`VIN`))
+ENGINE = InnoDB;
+
+
+-- -----------------------------------------------------
+-- Table `lab_mysql`.`Invoices`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `lab_mysql`.`Invoices` (
+  `Invoice_Number` INT NOT NULL,
+  `date` DATE NOT NULL,
+  `Customers_CustomerID` INT NOT NULL,
+  `Salespersons_StaffID` INT NOT NULL,
+  `Cars_VIN` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`Invoice_Number`, `Customers_CustomerID`, `Salespersons_StaffID`, `Cars_VIN`),
+  INDEX `fk_Invoices_Customers_idx` (`Customers_CustomerID` ASC),
+  INDEX `fk_Invoices_Salespersons1_idx` (`Salespersons_StaffID` ASC),
+  INDEX `fk_Invoices_Cars1_idx` (`Cars_VIN` ASC),
+  CONSTRAINT `fk_Invoices_Customers`
+    FOREIGN KEY (`Customers_CustomerID`)
+    REFERENCES `lab_mysql`.`Customers` (`CustomerID`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_Invoices_Salespersons1`
+    FOREIGN KEY (`Salespersons_StaffID`)
+    REFERENCES `lab_mysql`.`Salespersons` (`StaffID`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION,
+  CONSTRAINT `fk_Invoices_Cars1`
+    FOREIGN KEY (`Cars_VIN`)
+    REFERENCES `lab_mysql`.`Cars` (`VIN`)
+    ON DELETE NO ACTION
+    ON UPDATE NO ACTION)
+ENGINE = InnoDB;
+
+
+SET SQL_MODE=@OLD_SQL_MODE;
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;


### PR DESCRIPTION
hoy no pude adelantar mucho el ejercicio, pase la mayoria de la clase resolviendo los errores de mysql. 

para resolver los fallos de mysql tuve que seguir los siguientes pasos, que tambien he compartido en slack : 

Para ver todos los procesos que  sean de mysql
`ps -ax | grep mysql`
Eso genera una lista de procesos, cada uno empieza con un numero de ID

Para terminar (kill) esos procesos de mysql 
`sudo kill -TERM 111111`
Donde `111111` seria el numero del proceso en especifico que quieres eliminar.
Este comando hay que correrlo para cada proceso individualmente

Tambien, para desinstalar mysql, diego nos ha recomendado lso pasos al final del articulo 
https://www.sqlshack.com/how-to-install-mysql-on-ubuntu-18-04/

Finalmente, segui los pasos de este link que paso Jesus
https://www.digitalocean.com/community/tutorials/como-instalar-mysql-en-ubuntu-18-04-es


El error en una ocación hacia referencia a un `auth socket plugin` que debia cambiarse a `password confirmation`, resueltoespecificamente en el paso anterior
