### PR TITLE
[lab-map-reduce-filter] Diego Florez

### DIFF
--- a/module-1/lab-map-reduce-filter/your-code/main.ipynb
+++ b/module-1/lab-map-reduce-filter/your-code/main.ipynb
@@ -12,12 +12,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
     "# import reduce from functools, numpy and pandas\n",
-    "\n"
+    "\n",
+    "from functools import reduce\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import ssl\n",
+    "ssl._create_default_https_context = ssl._create_unverified_context"
    ]
   },
   {
@@ -33,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,12 +60,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Your code here:\n",
-    "\n"
+    "new_p = list(map(lambda x: x, prophet[568:]))"
    ]
   },
   {
@@ -72,12 +77,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['the{7}', 'chosen', 'and', 'the\\nbeloved,', 'who', 'was', 'a', 'dawn', 'unto']"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Your code here:\n",
-    "\n"
+    "\n",
+    "w10 = list(map(lambda x: x, new_p[1:10]))\n",
+    "w10"
    ]
   },
   {
@@ -91,9 +109,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 44,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'the'"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def reference(x):\n",
     "    '''\n",
@@ -107,7 +136,10 @@
     "    \n",
     "    # Your code here:\n",
     "    \n",
-    "    "
+    "    s = x.strip(\"{0123456789}\")\n",
+    "    return s\n",
+    "    \n",
+    "reference('the{7}')    "
    ]
   },
   {
@@ -119,12 +151,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Your code here:\n",
-    "\n"
+    "\n",
+    "prophet_reference = list(map(lambda x: reference(x),new_p))"
    ]
   },
   {
@@ -136,9 +169,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 50,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['the', 'beloved']"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def line_break(x):\n",
     "    '''\n",
@@ -151,8 +195,10 @@
     "    '''\n",
     "    \n",
     "    # Your code here:\n",
-    "    \n",
-    "    "
+    "    s = x.strip(\"\\n\")\n",
+    "    return s.split()\n",
+    "\n",
+    "line_break('the\\nbeloved')"
    ]
   },
   {
@@ -164,12 +210,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Your code here:\n",
-    "\n"
+    "\n",
+    "prophet_line = list(map(lambda x: line_break(x),prophet_reference))"
    ]
   },
   {
@@ -181,12 +228,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Your code here:\n",
-    "\n"
+    "\n",
+    "prophet_flat = [w for l in prophet_line for w in l]"
    ]
   },
   {
@@ -200,9 +248,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 64,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def word_filter(x):\n",
     "    '''\n",
@@ -221,8 +280,10 @@
     "    word_list = ['and', 'the', 'a', 'an']\n",
     "    \n",
     "    # Your code here:\n",
+    "    return True if x not in word_list else False\n",
     "    \n",
-    "    "
+    "    \n",
+    "word_filter('the')"
    ]
   },
   {
@@ -230,6 +291,15 @@
    "metadata": {},
    "source": [
     "Use the `filter()` function to filter out the words speficied in the `word_filter()` function. Store the filtered list in the variable `prophet_filter`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prophet_filter = list(filter(lambda x: word_filter(x), prophet_flat))"
    ]
   },
   {
@@ -243,9 +313,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 79,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def word_filter_case(x):\n",
     "   \n",
@@ -253,7 +334,21 @@
     "    \n",
     "    # Your code here:\n",
     "    \n",
-    "    "
+    "    wl = [w.title() for w in word_list]   #with title() we capitalize the 1st letter of each word\n",
+    "    \n",
+    "    return True if x not in word_list and x not in wl else False\n",
+    "    \n",
+    "\n",
+    "word_filter_case('And')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prophet_filter = list(filter(lambda x: word_filter_case(x), prophet_flat))"
    ]
   },
   {
@@ -269,9 +364,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 84,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'John Smith'"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def concat_space(a, b):\n",
     "    '''\n",
@@ -284,7 +390,8 @@
     "    '''\n",
     "    \n",
     "    # Your code here:\n",
-    "    "
+    "    return a+\" \"+b\n",
+    "concat_space('John', 'Smith')    "
    ]
   },
   {
@@ -296,12 +403,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Your code here:\n",
-    "\n"
+    "prophet_string = reduce(concat_space, prophet_filter)\n",
+    "#reduce() permite concatenar (en caso de str, si fuera numero suma) una lista, siempre y cuando creemos una\n",
+    "#funcion del tipo a+b previamente"
    ]
   },
   {
@@ -317,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,12 +447,179 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 104,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(43824, 13)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>No</th>\n",
+       "      <th>year</th>\n",
+       "      <th>month</th>\n",
+       "      <th>day</th>\n",
+       "      <th>hour</th>\n",
+       "      <th>pm2.5</th>\n",
+       "      <th>DEWP</th>\n",
+       "      <th>TEMP</th>\n",
+       "      <th>PRES</th>\n",
+       "      <th>cbwd</th>\n",
+       "      <th>Iws</th>\n",
+       "      <th>Is</th>\n",
+       "      <th>Ir</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>-21</td>\n",
+       "      <td>-11.0</td>\n",
+       "      <td>1021.0</td>\n",
+       "      <td>NW</td>\n",
+       "      <td>1.79</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>-21</td>\n",
+       "      <td>-12.0</td>\n",
+       "      <td>1020.0</td>\n",
+       "      <td>NW</td>\n",
+       "      <td>4.92</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>-21</td>\n",
+       "      <td>-11.0</td>\n",
+       "      <td>1019.0</td>\n",
+       "      <td>NW</td>\n",
+       "      <td>6.71</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>3</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>-21</td>\n",
+       "      <td>-14.0</td>\n",
+       "      <td>1019.0</td>\n",
+       "      <td>NW</td>\n",
+       "      <td>9.84</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>4</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>4</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>-20</td>\n",
+       "      <td>-12.0</td>\n",
+       "      <td>1018.0</td>\n",
+       "      <td>NW</td>\n",
+       "      <td>12.97</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   No  year  month  day  hour  pm2.5  DEWP  TEMP    PRES cbwd    Iws  Is  Ir\n",
+       "0   1  2010      1    1     0    NaN   -21 -11.0  1021.0   NW   1.79   0   0\n",
+       "1   2  2010      1    1     1    NaN   -21 -12.0  1020.0   NW   4.92   0   0\n",
+       "2   3  2010      1    1     2    NaN   -21 -11.0  1019.0   NW   6.71   0   0\n",
+       "3   4  2010      1    1     3    NaN   -21 -14.0  1019.0   NW   9.84   0   0\n",
+       "4   5  2010      1    1     4    NaN   -20 -12.0  1018.0   NW  12.97   0   0"
+      ]
+     },
+     "execution_count": 104,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Your code here:\n",
-    "\n"
+    "print(pm25.shape)\n",
+    "pm25.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['No', 'year', 'month', 'day', 'hour', 'pm2.5', 'DEWP', 'TEMP', 'PRES',\n",
+       "       'cbwd', 'Iws', 'Is', 'Ir'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 125,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm25.columns"
    ]
   },
   {
@@ -355,9 +631,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 105,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.0"
+      ]
+     },
+     "execution_count": 105,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def hourly(x):\n",
     "    '''\n",
@@ -370,7 +657,8 @@
     "    '''\n",
     "    \n",
     "    # Your code here:\n",
-    "    "
+    "    return(x/24)\n",
+    "hourly(48)"
    ]
   },
   {
@@ -382,12 +670,178 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 176,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Iws</th>\n",
+       "      <th>Is</th>\n",
+       "      <th>Ir</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>0.074583</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>0.205000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>0.279583</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>3</td>\n",
+       "      <td>0.410000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>4</td>\n",
+       "      <td>0.540417</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Iws   Is   Ir\n",
+       "0  0.074583  0.0  0.0\n",
+       "1  0.205000  0.0  0.0\n",
+       "2  0.279583  0.0  0.0\n",
+       "3  0.410000  0.0  0.0\n",
+       "4  0.540417  0.0  0.0"
+      ]
+     },
+     "execution_count": 176,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Your code here:\n",
-    "\n"
+    "\n",
+    "pm25_hourly = hourly(pm25[[\"Iws\",\"Is\",\"Ir\"]])\n",
+    "pm25_hourly.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Iws</th>\n",
+       "      <th>Is</th>\n",
+       "      <th>Ir</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1504</td>\n",
+       "      <td>0.130417</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.041667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1732</td>\n",
+       "      <td>0.037083</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.041667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1733</td>\n",
+       "      <td>0.018750</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.083333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1734</td>\n",
+       "      <td>0.130417</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.125000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1851</td>\n",
+       "      <td>0.074583</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.041667</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Iws   Is        Ir\n",
+       "1504  0.130417  0.0  0.041667\n",
+       "1732  0.037083  0.0  0.041667\n",
+       "1733  0.018750  0.0  0.083333\n",
+       "1734  0.130417  0.0  0.125000\n",
+       "1851  0.074583  0.0  0.041667"
+      ]
+     },
+     "execution_count": 177,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#pm25_hourly cuando \"Ir\" != 0\n",
+    "pm25_hourly[pm25_hourly[\"Ir\"]!=0][[\"Iws\",\"Is\",\"Ir\"]].head()"
    ]
   },
   {
@@ -401,9 +855,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 116,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.37267799624996495"
+      ]
+     },
+     "execution_count": 116,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def sample_sd(x):\n",
     "    '''\n",
@@ -416,16 +881,35 @@
     "    '''\n",
     "    \n",
     "    # Your code here:\n",
+    "    return (np.std(x))/(x.count()-1) #por que /n-1 si la sdt lo deberia incluir?\n",
     "    \n",
-    "    "
+    "    \n",
+    "sample_sd(pd.Series([1,2,3,4]))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 117,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Iws    4.754929e-05\n",
+       "Is     7.229519e-07\n",
+       "Ir     1.346183e-06\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#calculando las std de las 3 columnas\n",
+    "pm25_hourly.apply(lambda x: sample_sd(x))"
+   ]
   }
  ],
  "metadata": {
@@ -444,7 +928,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
he tenido 3 dudas :smile: 
1. en el primer punto, dentro del codigo `prophet = f.read().split(' ')`, que es lo crea ,',? Despues de Almustafa por ejemplo.
ex:

> """['PROPHET',
 '|Almustafa,',
 'chosen',
 'beloved,',
 'who',
 'was',
 'dawn'"""

2. volviendo a lo mismo, pero al contrario, dentro del codigo `prophet_string = reduce(concat_space, prophet_filter)`, como indetifica ,', para eliminarlo y asi hacer bien el string entero de prophet?

3. por que en el ultimo punto del challenge 4 hay que dividir por n-1? no deberia estar implicito in np.std?

ps: luego tengo aun duda de como moverme bien por los df con pandas, tipo:
como sacar las tres columnas cuando los valor de "Ir" & "Is" son != 0 -->
`pm25_hourly[pm25_hourly["Ir"]!=0][["Iws","Is","Ir"]].head()` osea esto pero con & Is !=0 tambien
pero imagino que me quedara mas claro despues del finde con el proyecto :joy: 